### PR TITLE
Fixed UI bugs on query group editing & handled empty results gracefully

### DIFF
--- a/app/controllers/api/v1/results_controller.rb
+++ b/app/controllers/api/v1/results_controller.rb
@@ -7,13 +7,13 @@ class Api::V1::ResultsController < Api::V1::BaseController
   before_action :validate_score_params, only: [:register_score]
 
   def index
-    render json: { result: @query.active_result, score: @query.active_result.active_score, notice: "Fetched the latest query results!" }
+    render json: { result: @query.active_result, score: @query.active_result.try(:active_score), notice: "Fetched the latest query results!" }
   end
 
   def fetch_fresh_results
     @result = @query.fetch_fresh_results!
     if @result && !@result.errors.present?
-      render json: { result: @result, score: @result.active_score, notice: "Fetched the latest query results!" }
+      render json: { result: @result, score: @result.try(:active_score), notice: "Fetched the latest query results!" }
     else
       render json: { error: "Some error occurred." }, status: 422
     end

--- a/app/helpers/api_request_manager.rb
+++ b/app/helpers/api_request_manager.rb
@@ -6,8 +6,14 @@ class ApiRequestManager
   end
 
   def do_post
-    log_req
-    @res = RestClient.post(formatted_uri, formatted_request_body.to_json, custom_headers.merge({ content_type: :json }))
+    log_req 'POST'
+    # @res = RestClient.post(formatted_uri, formatted_request_body.to_json, custom_headers.merge({ content_type: :json }))
+    @res = RestClient::Request.execute(method: :post,
+      url: formatted_uri,
+      payload: formatted_request_body.to_json,
+      headers: custom_headers.merge({ content_type: :json }),
+      verify_ssl: false
+    )
     JSON.parse(@res.body)
   rescue RestClient::ExceptionWithResponse => e
     @errors = e.response
@@ -15,7 +21,7 @@ class ApiRequestManager
   end
 
   def do_get
-    log_req
+    log_req 'GET'
     @res = RestClient.get(formatted_uri, custom_headers)
     JSON.parse(@res.body)
   rescue RestClient::ExceptionWithResponse => e
@@ -31,9 +37,9 @@ class ApiRequestManager
     }
   end
 
-  def log_req
+  def log_req req_method
     puts '#'*50
-    puts "Sending request to #{formatted_uri}"
+    puts "[#{req_method}] #{formatted_uri}"
   end
 
   def formatted_uri

--- a/app/javascript/src/components/Dashboard/QueryGroups/ListPage.jsx
+++ b/app/javascript/src/components/Dashboard/QueryGroups/ListPage.jsx
@@ -14,7 +14,9 @@ export default function ListPage({
           <tr>
             <th> ID </th>
             <th className="text-left">Name</th>
-            <th className="text-left">Method / Document Fields</th>
+            <th className="text-left">Method</th>
+            <th className="text-left">Document Unique Field</th>
+            <th className="text-left">Document Fields</th>
             <th className="text-left">Actions</th>
           </tr>
         </thead>
@@ -37,7 +39,9 @@ export default function ListPage({
                   </div>
                 </NavLink>
               </td>
-              <td>{queryGroup.http_method} | {queryGroup.document_fields}</td>
+              <td>{queryGroup.http_method}</td>
+              <td>{queryGroup.document_uuid}</td>
+              <td>[{queryGroup.document_fields.join(', ')}]</td>
               <td>
                 <Button
                   onClick={() => { setCurrrentResource(queryGroup); showPane(true); } }

--- a/app/javascript/src/components/Dashboard/QueryGroups/NewForm.jsx
+++ b/app/javascript/src/components/Dashboard/QueryGroups/NewForm.jsx
@@ -14,17 +14,8 @@ const getList = async (service) => {
   return response.data.map((resource) => ({ value: resource.id, label: resource.name }));
 }
 
-const RequestTypeInputField = ({ showQueryStringField }) => {
-  if(showQueryStringField) {
-    return (<Input label="Query String" name="query_string" rows={8} className="mb-6" />);
-  } else {
-    return (<Textarea label="Request Body" name="request_body" rows={8} className="mb-6" />);
-  }
-}
-
 const preProcessObject = (resource) => {
   resource.request_body = deserializeObject(resource.request_body);
-  resource.transform_response = deserializeObject(resource.transform_response);
   resource.document_fields = resource.document_fields.split(',');
 
   if(typeof resource.api_source_id === 'object' && resource.api_source_id !== null) {
@@ -32,6 +23,9 @@ const preProcessObject = (resource) => {
   }
   if(typeof resource.scorer_id === 'object' && resource.scorer_id !== null) {
     resource.scorer_id = resource.scorer_id.value;
+  }
+  if(typeof resource.http_method === 'object' && resource.http_method !== null) {
+    resource.http_method = resource.http_method.value;
   }
   return resource;
 }
@@ -51,7 +45,6 @@ const defaultValues = (currentResource) => {
   };
 
   resourceObj.request_body = serializeObject(resourceObj.request_body);
-  resourceObj.transform_response = serializeObject(resourceObj.transform_response);
   if(Array.isArray(resourceObj.document_fields)) {
     resourceObj.document_fields = resourceObj.document_fields.join(',');
   }
@@ -63,7 +56,6 @@ const defaultValues = (currentResource) => {
 export default function NewForm({ onClose, refetch, currentResource }) {
   const [loading, setLoading] = useState(true);
   const [resourceObject, setResourceObject] = useState(defaultValues(currentResource));
-  const [showQueryStringField, setShowQueryStringField] = useState(resourceObject.http_method === 'GET');
   const [scorerOptions, setScorerOptions] = useState([]);
   const [sourcesOptions, setSourcesOptions] = useState([]);
 
@@ -106,7 +98,6 @@ export default function NewForm({ onClose, refetch, currentResource }) {
       onSubmit={handleSubmit}
       validationSchema={yup.object({
         name: yup.string().required("Name is required"),
-        http_method: yup.string().required("HTTP Method is required"),
         page_size: yup.number().required("Page Size is required"),
         document_uuid: yup.string().required("Unique Document Field is required"),
         document_fields: yup.string().required("Document fields are required"),
@@ -140,9 +131,6 @@ export default function NewForm({ onClose, refetch, currentResource }) {
             label="Request Type"
             placeholder="Select an Option"
             name="http_method"
-            onChange={(opt) => {
-              setShowQueryStringField(opt.value === 'GET');
-            } }
             options={[
               { value: "GET", label: "GET" },
               { value: "POST", label: "POST" },
@@ -150,10 +138,12 @@ export default function NewForm({ onClose, refetch, currentResource }) {
             className="mb-6"
           />
 
-          <RequestTypeInputField showQueryStringField={showQueryStringField} />
+          <Input label="Query String" name="query_string" rows={8} className="mb-6" />
+          <Textarea label="Request Body" name="request_body" rows={8} className="mb-6" />
+
           <Input label="Unique Document Field" name="document_uuid" type="String" className="mb-6" />
           <Input label="Fields to Display" name="document_fields" type="String" className="mb-6" />
-          <Textarea label="Transform Response" name="transform_response" rows={8} className="mb-6" />
+          <Textarea label="Transform Response" name="transform_response" rows={8} className="mb-10" />
           <div className="nui-pane__footer nui-pane__footer--absolute">
             <Button
               onClick={onClose}


### PR DESCRIPTION
* Fixed the UI bugs on query group editing, POST/GET selection and dependant fields, JSON parsing of the request body field
* Updated the REST client options to support un-verified SSL calls
* Additional info on Query group listing
* Handled empty results from 500-ing while fetching score for nil result