### PR TITLE
Configurable scorers with defaults (CG, CDG, nDCG, AP)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,9 @@ gem "letter_opener", group: :development
 # send http calls
 gem "rest-client"
 
+# for executing javascript
+gem "mini_racer"
+
 group :development, :test do
   # Rails integration for factory-bot
   gem "factory_bot_rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,6 +158,7 @@ GEM
       addressable (~> 2.7)
     letter_opener (1.7.0)
       launchy (~> 2.2)
+    libv8-node (15.14.0.1)
     listen (3.3.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -175,6 +176,8 @@ GEM
     mime-types-data (3.2021.0704)
     mini_mime (1.0.3)
     mini_portile2 (2.5.1)
+    mini_racer (0.4.0)
+      libv8-node (~> 15.14.0.0)
     minitest (5.14.4)
     minitest-ci (3.4.0)
       minitest (>= 5.0.6)
@@ -356,6 +359,7 @@ DEPENDENCIES
   letter_opener
   listen (~> 3.2)
   mail_interceptor
+  mini_racer
   minitest
   minitest-ci
   pg

--- a/app/helpers/api_request_manager.rb
+++ b/app/helpers/api_request_manager.rb
@@ -16,6 +16,7 @@ class ApiRequestManager
     )
     JSON.parse(@res.body)
   rescue RestClient::ExceptionWithResponse => e
+    puts e.inspect
     @errors = e.response
     e.response
   end

--- a/app/helpers/javascript_evaluator.rb
+++ b/app/helpers/javascript_evaluator.rb
@@ -1,0 +1,36 @@
+# Interface for using this module:
+#
+# Example code:
+#         code = `var userName = name();
+#           var helloMessage = `Hello ${userName}`;
+#           helloMessage`;
+#         params = {
+#           name: "Sony"
+#         };
+#         js = JavascriptEvaluator.new({ code: code, params: params)
+#         js.result
+# => "Hello Sony"
+
+class JavascriptEvaluator
+  attr_accessor :options, :errors
+
+  def initialize(options)
+    @options = options
+    @js_code = options[:code]
+    @params = options[:params]
+  end
+
+  def result
+    context = MiniRacer::Context.new
+
+    @params.each do |key, value|
+      context.attach(key.to_s, proc{ value })
+    end
+
+    evaluated_result = context.eval @js_code
+    puts "JS Execution Result: ", evaluated_result
+    puts "Params: ", @params.inspect
+    evaluated_result
+  end
+
+end

--- a/app/javascript/src/apis/axios.js
+++ b/app/javascript/src/apis/axios.js
@@ -27,7 +27,7 @@ const handleSuccessResponse = response => {
   if (response) {
     response.success = response.status === 200;
     if (response.data.notice) {
-      Toastr.success(response.data.notice);
+      // Toastr.success(response.data.notice);
     }
   }
   return response;

--- a/app/javascript/src/common/colorHelper.js
+++ b/app/javascript/src/common/colorHelper.js
@@ -15,12 +15,14 @@ const COLORS = {
 
 const colorForScaleValue = (scaleSize = 2, scaleValue = 0) => {
   let roundedScaleValue = Math.round(scaleValue);
-  return COLORS[scaleSize][roundedScaleValue];
+  let defaultColor = COLORS[2][1];
+  return COLORS[scaleSize][roundedScaleValue] || defaultColor;
 }
 
 const colorForBinaryRating = (rating = 0, scaleSize = 10) => {
   let roundedRating = Math.round(rating * 10);
-  return COLORS[scaleSize][roundedRating];
+  let defaultColor = COLORS[2][1];
+  return COLORS[scaleSize][roundedRating] || defaultColor;
 }
 
 export { COLORS, colorForScaleValue, colorForBinaryRating };

--- a/app/javascript/src/components/Dashboard/Queries/ListPage.jsx
+++ b/app/javascript/src/components/Dashboard/Queries/ListPage.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { NavLink } from "react-router-dom";
+import { Tooltip } from "neetoui";
 import { colorForBinaryRating } from 'common/colorHelper';
 import { timeSince } from "common/timeHelper";
 
@@ -37,10 +38,12 @@ export default function ListPage({
                     onClick={e => setCurrrentResource(query) }
                   >
                     <div className="flex flex-row space-x-2 text-gray-900 items-center">
-                      <div className="rounded flex text-white text-xl font-semibold items-center justify-center w-14 h-10"
-                        style={{backgroundColor: colorForBinaryRating(query.latest_score || 0.0)}}
-                      > { (query.latest_score || 0.0).toFixed(2) }
-                      </div>
+                      <Tooltip content={`Latest Score (${scorer.name})`} position="bottom" minimal>
+                        <div className="rounded flex text-white text-xl font-semibold items-center justify-center w-14 h-10"
+                          style={{backgroundColor: colorForBinaryRating(query.latest_score || 0.0)}}
+                        > { (query.latest_score || 0.0).toFixed(2) }
+                        </div>
+                      </Tooltip>
                       <div>
                         {query.query_text}
                       </div>

--- a/app/javascript/src/components/Dashboard/QueryGroups/NewForm.jsx
+++ b/app/javascript/src/components/Dashboard/QueryGroups/NewForm.jsx
@@ -16,7 +16,7 @@ const getList = async (service) => {
 
 const preProcessObject = (resource) => {
   resource.request_body = deserializeObject(resource.request_body);
-  resource.document_fields = resource.document_fields.split(',');
+  resource.document_fields = resource.document_fields.split(',').map((val) => val.trim());
 
   if(typeof resource.api_source_id === 'object' && resource.api_source_id !== null) {
     resource.api_source_id = resource.api_source_id.value;
@@ -46,7 +46,7 @@ const defaultValues = (currentResource) => {
 
   resourceObj.request_body = serializeObject(resourceObj.request_body);
   if(Array.isArray(resourceObj.document_fields)) {
-    resourceObj.document_fields = resourceObj.document_fields.join(',');
+    resourceObj.document_fields = resourceObj.document_fields.join(', ');
   }
 
   return resourceObj;

--- a/app/javascript/src/components/Dashboard/Results/ListPage.jsx
+++ b/app/javascript/src/components/Dashboard/Results/ListPage.jsx
@@ -3,6 +3,7 @@ import { Button, Card, Tooltip } from "neetoui";
 
 import { colorForScaleValue } from 'common/colorHelper';
 import resultService from "apis/resultService";
+import QueryGroups from "../QueryGroups";
 
 export default function ListPage({
   scorer,
@@ -17,7 +18,7 @@ export default function ListPage({
 
   const [showRatingPaneFor, setShowRatingPaneFor] = useState(false);
 
-  const getUserRatingFor = (doc) => {
+  const displayUserRatingFor = (doc) => {
     if(!doc || !scores) {
       return (<Button
         onClick={() => { setCurrrentResource(doc); setShowRatingPaneFor(doc); } }
@@ -46,33 +47,40 @@ export default function ListPage({
     }
   }
 
-  const getFieldsFor = (doc) => {
+  const displayFieldsFor = (doc) => {
+    let allFields = {};
+    for(let i = 0; i < queryGroup['document_fields'].length; ++i) {
+      const key = queryGroup['document_fields'][i];
+      allFields[key] = doc[key];
+    }
+
     return (
       <>
-      <div className="flex flex-row space-x-4 text-gray-900">
-        <div className="flex-1 flex flex-col">
-          {queryGroup['document_fields'].map(field => {
-            return (
-              <div key={field} className="flex flex-row space-x-4 text-gray-900">
-                <div>{field}: </div>
-                <div>{doc[field]}</div>
-              </div>
-            );
-          })}
+        <div className="flex flex-row space-x-4 text-gray-900">
+          <div className="flex-1 flex flex-col">
+            {Object.keys(allFields).map(field => {
+              return (
+                <div key={field} className="flex flex-row space-x-4 text-gray-900">
+                  <div>{field}: </div>
+                  <div>{allFields[field]}</div>
+                </div>
+              );
+            })}
+          </div>
+          <div>
+            <Tooltip content="Rate this result" position="bottom" minimal>
+              {displayUserRatingFor(doc)}
+            </Tooltip>
+          </div>
         </div>
-        <div>
-          <Tooltip content="Rate this result" position="bottom" minimal>
-            {getUserRatingFor(doc)}
-          </Tooltip>
-        </div>
-      </div>
-    </>);
+      </>
+    );
   }
 
   const getRatingsPanelFor = (doc) => {
     const rateDoc = async (value) => {
       try {
-        console.log(value, doc);
+        // console.log(value, doc);
         const payload = {
           doc: doc,
           score: value
@@ -112,7 +120,7 @@ export default function ListPage({
       {items.map(doc => (
         <Card key={doc[queryGroup['document_uuid']]} className="relative">
           <Card.Title>{doc[queryGroup['document_uuid']]}</Card.Title>
-          <div>{getFieldsFor(doc)}</div>
+          <div>{displayFieldsFor(doc)}</div>
           { (showRatingPaneFor &&  showRatingPaneFor === doc) ? 
               (<div className="absolute inset-y-1 right-4">{getRatingsPanelFor(doc)}</div>)
               : ''

--- a/app/javascript/src/components/Dashboard/Results/index.jsx
+++ b/app/javascript/src/components/Dashboard/Results/index.jsx
@@ -76,7 +76,7 @@ const QueryResult = ({ scorer, queryGroup, query, setCurrrentQuery, showQueryEdi
                       (Updated {timeSince(new Date(queryResult.updated_at))} ago)
                     </div>
                   </Tooltip>
-                  <Tooltip content="Latest Score" position="bottom" minimal>
+                  <Tooltip content={`Latest Score (${scorer.name})`} position="bottom" minimal>
                     <div className="rounded-md text-white text-xl font-semibold pr-2 pl-2 pt-0.5 pb-0.5"
                       style={{backgroundColor: colorForBinaryRating(queryResult.latest_score || 0.0)}}
                       > { (queryResult.latest_score || 0.0).toFixed(2) }

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -24,8 +24,12 @@ class Result < ApplicationRecord
     active_score.ratings
   end
 
-  def recalculate_final_score!
+  def recalculate_final_score
     self.latest_score = query_group.scorer.calculate_score_for(query_group.document_uuid, ratings, self.data)
+  end
+
+  def recalculate_final_score!
+    recalculate_final_score
     self.save!
     self.latest_score
   end

--- a/lib/tasks/scorers.md
+++ b/lib/tasks/scorers.md
@@ -1,0 +1,97 @@
+Default Scorers provided out of the box
+
+```
+// Example
+var docPositionAndValues = () => ({ 1: 1, 2: 0, 3: 1, 4: 0, 5: 1})
+var docPositionAndValues = () => ({1: 3, 2: 2, 3: 3, 4: 0, 5: 1, 6: 2})
+```
+
+## Average Precision
+
+```
+// Average Precision
+
+var positionAndValues = docPositionAndValues();
+var largestPosition = Math.max(...Object.keys(positionAndValues));
+var countRelevantDocuments = 0, 
+    allDocPrecisions = [],
+    relevantDocsPrecisions = [];
+for(var i = 1; i <= largestPosition; ++i) {
+    console.log(i, positionAndValues[i])
+    if(positionAndValues[i] === 1) {
+        countRelevantDocuments += 1
+        relevantDocsPrecisions.push(parseFloat(countRelevantDocuments) / i)
+    }
+    allDocPrecisions.push(parseFloat(countRelevantDocuments) / i);
+}
+var numerator = relevantDocsPrecisions.reduce((a, b) => a + b, 0),
+    denominator = Math.max(relevantDocsPrecisions.length, 1);
+averagePrecison = numerator / denominator;
+averagePrecison
+```
+
+## Cumulative Gain (CG)
+
+```
+// Cumulative Gain (CG)
+var positionAndValues = docPositionAndValues();
+var allValues = Object.keys(positionAndValues).map((pos) => positionAndValues[pos]);
+var cg = allValues.reduce((a, b) => a + b, 0);
+cg
+```
+
+## Discounted Cumulative Gain (DCG)
+
+```
+// Discounted Cumulative Gain (DCG)
+var allDocPositionAndValues = docPositionAndValues();
+
+// first approach - ( relevance / log2(i + 1) )
+// second approach (better penalizing of relevant results appearing lower) - ( (pow2(relevance) - 1) / log2(i + 1) )
+function findDcgFor(positionAndValues) {
+    var individualDCGs = [];
+    var positions = Object.keys(positionAndValues);
+    for(var i = 0; i < positions.length; ++i) {
+        var numerator = Math.pow(2, positionAndValues[positions[i]]) - 1;
+        individualDCGs.push(parseFloat(numerator) / Math.log2(positions[i] + 1));
+    }
+    dcg = individualDCGs.reduce((a, b) => a + b, 0);
+    return dcg;
+};
+findDcgFor(allDocPositionAndValues)
+```
+
+## normalized Discounted Cumulative Gain (nDCG) 
+
+```
+// normalized Discounted Cumulative Gain (nDCG)
+var allDocPositionAndValues = docPositionAndValues();
+
+function findDcgFor(positionAndValues) {
+    var individualDCGs = [];
+    var positions = Object.keys(positionAndValues);
+    for(var i = 0; i < positions.length; ++i) {
+        var numerator = Math.pow(2, positionAndValues[positions[i]]) - 1;
+        individualDCGs.push(parseFloat(numerator) / Math.log2(positions[i] + 1));
+    }
+    dcg = individualDCGs.reduce((a, b) => a + b, 0);
+    return dcg;
+};
+
+function findNdcgFor(positionAndValues) {
+    var allValues = Object.keys(positionAndValues).map((pos) => (positionAndValues[pos]));
+    var topValues = allValues.sort((a, b) => (b - a)),
+        idealPositionAndValues = {};
+
+    var sortedPositions = Object.keys(positionAndValues).sort();
+    for(var i = 0; i < sortedPositions.length; i++){
+        idealPositionAndValues[sortedPositions[i]] = topValues[i];
+    }
+    var dcg = findDcgFor(positionAndValues),
+        idcg = findDcgFor(idealPositionAndValues);
+    var ndcg = (dcg / idcg);
+    return ndcg;
+}
+
+findNdcgFor(allDocPositionAndValues)
+```

--- a/lib/tasks/setup.rake
+++ b/lib/tasks/setup.rake
@@ -68,16 +68,99 @@ end
 
 def create_scorers!
   attributes = {
-    name: 'Hello Scorer',
-    code: '<>',
+    name: 'Average Precision (AP)',
+    code: "// Average Precision (AP)
+      var positionAndValues = docPositionAndValues();
+      var largestPosition = Math.max(...Object.keys(positionAndValues));
+      var countRelevantDocuments = 0, 
+          allDocPrecisions = [],
+          relevantDocsPrecisions = [];
+      for(var i = 1; i <= largestPosition; ++i) {
+          console.log(i, positionAndValues[i])
+          if(positionAndValues[i] === 1) {
+              countRelevantDocuments += 1
+              relevantDocsPrecisions.push(parseFloat(countRelevantDocuments) / i)
+          }
+          allDocPrecisions.push(parseFloat(countRelevantDocuments) / i);
+      }
+      var numerator = relevantDocsPrecisions.reduce((a, b) => a + b, 0),
+          denominator = Math.max(relevantDocsPrecisions.length, 1);
+      averagePrecison = numerator / denominator;
+      averagePrecison",
     scale_type: 'binary'
+  }
+  Scorer.create! attributes
+  attributes = {
+    name: 'Cumulative Gain (CG)',
+    code: "// Cumulative Gain (CG)
+    var positionAndValues = docPositionAndValues();
+    var allValues = Object.keys(positionAndValues).map((pos) => positionAndValues[pos]);
+    var cg = allValues.reduce((a, b) => a + b, 0);
+    cg",
+    scale_type: 'graded'
+  }
+  Scorer.create! attributes
+  attributes = {
+    name: 'Discounted Cumulative Gain (DCG)',
+    code: "// Discounted Cumulative Gain (DCG)
+    var allDocPositionAndValues = docPositionAndValues();
+    
+    // first approach - ( relevance / log2(i + 1) )
+    // second approach (better penalizing of relevant results appearing lower) - ( (pow2(relevance) - 1) / log2(i + 1) )
+    function findDcgFor(positionAndValues) {
+        var individualDCGs = [];
+        var positions = Object.keys(positionAndValues);
+        for(var i = 0; i < positions.length; ++i) {
+            var numerator = Math.pow(2, positionAndValues[positions[i]]) - 1;
+            individualDCGs.push(parseFloat(numerator) / Math.log2(positions[i] + 1));
+        }
+        dcg = individualDCGs.reduce((a, b) => a + b, 0);
+        return dcg;
+    };
+    findDcgFor(allDocPositionAndValues)",
+    scale_type: 'graded'
+  }
+  Scorer.create! attributes
+  attributes = {
+    name: 'Normlaized Discounted Cumulative Gain (nDCG)',
+    code: "// normalized Discounted Cumulative Gain (nDCG)
+    var allDocPositionAndValues = docPositionAndValues();
+    
+    function findDcgFor(positionAndValues) {
+        var individualDCGs = [];
+        var positions = Object.keys(positionAndValues);
+        for(var i = 0; i < positions.length; ++i) {
+            var numerator = Math.pow(2, positionAndValues[positions[i]]) - 1;
+            individualDCGs.push(parseFloat(numerator) / Math.log2(positions[i] + 1));
+        }
+        dcg = individualDCGs.reduce((a, b) => a + b, 0);
+        return dcg;
+    };
+    
+    function findNdcgFor(positionAndValues) {
+        var allValues = Object.keys(positionAndValues).map((pos) => (positionAndValues[pos]));
+        var topValues = allValues.sort((a, b) => (b - a)),
+            idealPositionAndValues = {};
+    
+        var sortedPositions = Object.keys(positionAndValues).sort();
+        for(var i = 0; i < sortedPositions.length; i++){
+            idealPositionAndValues[sortedPositions[i]] = topValues[i];
+        }
+        var dcg = findDcgFor(positionAndValues),
+            idcg = findDcgFor(idealPositionAndValues);
+        var ndcg = (dcg / idcg);
+        return ndcg;
+    }
+    
+    findNdcgFor(allDocPositionAndValues)",
+    scale_type: 'graded'
   }
   Scorer.create! attributes
 end
 
 def create_query_group!(options = {})
   query_group_attributes = {
-    name: 'My Query Group',
+    name: 'NPM JS Prod Test Query Group',
     api_source_id: ApiSource.first.id,
     scorer_id: Scorer.first.id,
     http_method: 'GET',


### PR DESCRIPTION
* More Logging in RestClient requests
* Removed toaster on successful PAI responses
* Fixed bug with document_fields trimming
* Better naming and code in results list page - regarding displaying fields of the doc
* Added mini racer gem for evaluating scorers written in javascript
* New javascript evaluator module which takes care of passing arguments to Javascript and evaluating it
* Cleaned up scorer model to execute javascript-based scorer configured in the database itself to calculate the score
* Added doc for default scorers and its code
* added the default scorers to the seed
* Added tooltip to show scorer name while hovering over the score
* Updated the colorHelper for the default case