### PR TITLE
Moving to liquid templating for request body & query string

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,9 @@ gem "rest-client"
 # for executing javascript
 gem "mini_racer"
 
+# for templating
+gem "liquid"
+
 group :development, :test do
   # Rails integration for factory-bot
   gem "factory_bot_rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,7 +158,8 @@ GEM
       addressable (~> 2.7)
     letter_opener (1.7.0)
       launchy (~> 2.2)
-    libv8-node (15.14.0.1)
+    libv8-node (15.14.0.1-x86_64-darwin-20)
+    liquid (5.0.1)
     listen (3.3.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -357,6 +358,7 @@ DEPENDENCIES
   honeybadger
   jbuilder (>= 2.7)
   letter_opener
+  liquid
   listen (~> 3.2)
   mail_interceptor
   mini_racer

--- a/app/controllers/api/v1/results_controller.rb
+++ b/app/controllers/api/v1/results_controller.rb
@@ -12,10 +12,10 @@ class Api::V1::ResultsController < Api::V1::BaseController
 
   def fetch_fresh_results
     @result = @query.fetch_fresh_results!
-    if @result && !@result.errors.present?
+    if @result && !@result.try(:errors).present? && !(@result.is_a?(Hash) && @result[:error].present?)
       render json: { result: @result, score: @result.try(:active_score), notice: "Fetched the latest query results!" }
     else
-      render json: { error: "Some error occurred." }, status: 422
+      render json: { error: "Some error occurred.", details: @result.try(:errors) || @result  }, status: 422
     end
   end
 

--- a/app/helpers/api_request_manager.rb
+++ b/app/helpers/api_request_manager.rb
@@ -51,13 +51,13 @@ class ApiRequestManager
   end
 
   def template_transform(str)
-    template = ERB.new(str)
-    template.result_with_hash(query: @options[:query_text])
+    template = Liquid::Template.parse(str)
+    template.render('query' => @options[:query_text], 'page_size' => @options[:page_size], 'page_number' => @options[:page_number])
   end
 
   def formatted_request_body
-    template = ERB.new(JSON.generate(@options[:body]))
-    res = template.result_with_hash(query: @options[:query_text])
-    JSON.parse(res)
+    template = Liquid::Template.parse(JSON.generate(@options[:body]))
+    rendered_template = template.render('query' => @options[:query_text], 'page_size' => @options[:page_size], 'page_number' => @options[:page_number])
+    JSON.parse(rendered_template)
   end
 end

--- a/app/helpers/javascript_evaluator.rb
+++ b/app/helpers/javascript_evaluator.rb
@@ -1,15 +1,16 @@
 # Interface for using this module:
 #
 # Example code:
-#         code = `var userName = name();
-#           var helloMessage = `Hello ${userName}`;
-#           helloMessage`;
-#         params = {
-#           name: "Sony"
-#         };
-#         js = JavascriptEvaluator.new({ code: code, params: params)
-#         js.result
-# => "Hello Sony"
+#     code = "var userObj = user();
+#         userObj.address = 'Kerala';
+#         userObj";
+#     params = {
+#         user: { name: 'John Doe', age: 20 }
+#     };
+#     js = JavascriptEvaluator.new({ code: code, params: params })
+#     js.result
+#
+# => {"name"=>"John Doe", "age"=>20, "address"=>"Kerala"}
 
 class JavascriptEvaluator
   attr_accessor :options, :errors

--- a/app/javascript/src/components/Dashboard/ApiSources/NewApiSourceForm.jsx
+++ b/app/javascript/src/components/Dashboard/ApiSources/NewApiSourceForm.jsx
@@ -46,7 +46,7 @@ export default function NewApiSourceForm({ onClose, refetch, apiSource }) {
           <Input label="Name" name="name" className="mb-6" />
           <Input label="Environment" name="environment" className="mb-6" />
           <Input label="Host" name="host" className="mb-6" />
-          <Textarea label="Request" name="request" rows={8} />
+          <Textarea label="Request" name="request" rows={8} className="mb-24"/>
           <div className="nui-pane__footer nui-pane__footer--absolute">
             <Button
               onClick={onClose}

--- a/app/javascript/src/components/Dashboard/ApiSources/NewApiSourceForm.jsx
+++ b/app/javascript/src/components/Dashboard/ApiSources/NewApiSourceForm.jsx
@@ -5,13 +5,16 @@ import { Input, Textarea } from "neetoui/formik";
 import { Button } from "neetoui";
 import apiSourceService from "apis/apiSourceService";
 
+import { serializeObject, deserializeObject } from "common/jsonHelper";
+
 export default function NewApiSourceForm({ onClose, refetch, apiSource }) {
-  const handleSubmit = async values => {
+  const handleSubmit = async resource => {
     try {
+      resource.request = deserializeObject(resource.request);
       if(apiSource) {
-        await apiSourceService.update(apiSource.id, values);
+        await apiSourceService.update(apiSource.id, resource);
       } else {
-        await apiSourceService.create(values);
+        await apiSourceService.create(resource);
       }
       refetch();
       onClose();
@@ -21,14 +24,14 @@ export default function NewApiSourceForm({ onClose, refetch, apiSource }) {
   };
 
   const getInitialValues = () => {
-    const initialValues = apiSource || {
+    const resourceObj = apiSource || {
       name: "",
       host: "",
       environment: "",
-      request: []
+      request: {}
     };
-
-    return initialValues;
+    resourceObj.request = serializeObject(resourceObj.request);
+    return resourceObj;
   };
 
   return (
@@ -38,7 +41,7 @@ export default function NewApiSourceForm({ onClose, refetch, apiSource }) {
       validationSchema={yup.object({
         name: yup.string().required("Name is required"),
         host: yup.string().required("Host is required"),
-        environment: yup.string().required("Host is required"),
+        environment: yup.string().required("Environment is required"),
       })}
     >
       {({ isSubmitting }) => (
@@ -46,7 +49,7 @@ export default function NewApiSourceForm({ onClose, refetch, apiSource }) {
           <Input label="Name" name="name" className="mb-6" />
           <Input label="Environment" name="environment" className="mb-6" />
           <Input label="Host" name="host" className="mb-6" />
-          <Textarea label="Request" name="request" rows={8} className="mb-24"/>
+          <Textarea label="Request Headers" name="request" rows={8} className="mb-24"/>
           <div className="nui-pane__footer nui-pane__footer--absolute">
             <Button
               onClick={onClose}

--- a/app/javascript/src/components/Dashboard/Queries/ListPage.jsx
+++ b/app/javascript/src/components/Dashboard/Queries/ListPage.jsx
@@ -6,6 +6,7 @@ import { timeSince } from "common/timeHelper";
 
 export default function ListPage({
   items = [],
+  queryGroup,
   scorer,
   setCurrrentResource,
   showPane,
@@ -24,7 +25,7 @@ export default function ListPage({
       <table className="nui-table nui-table--checkbox">
         <thead>
           <tr>
-            <th className="text-left">Queries</th>
+            <th className="text-left"> {queryGroup.name} </th>
           </tr>
         </thead>
         <tbody className="w-full">

--- a/app/javascript/src/components/Dashboard/Queries/NewForm.jsx
+++ b/app/javascript/src/components/Dashboard/Queries/NewForm.jsx
@@ -88,7 +88,7 @@ export default function NewForm({ onClose, refetch, currentResource }) {
             isSearchable={true}
             name="query_group_id"
             options={queryGroupsOptions}
-            className="mb-6"
+            className="mb-24"
           />
           <div className="nui-pane__footer nui-pane__footer--absolute">
             <Button

--- a/app/javascript/src/components/Dashboard/Queries/index.jsx
+++ b/app/javascript/src/components/Dashboard/Queries/index.jsx
@@ -74,6 +74,7 @@ const QueryModel = () => {
             {queries.length ? (
             <>
               <ListPage
+                queryGroup={queryGroup}
                 items={queries}
                 scorer={scorer}
                 setCurrrentResource={setCurrrentResource}

--- a/app/javascript/src/components/Dashboard/QueryGroups/ListPage.jsx
+++ b/app/javascript/src/components/Dashboard/QueryGroups/ListPage.jsx
@@ -1,12 +1,20 @@
 import React from "react";
 import { NavLink } from "react-router-dom";
 import { Button } from "neetoui";
+import QueryGroups from ".";
 
 export default function ListPage({
   items = [],
   setCurrrentResource,
   showPane
 }) {
+  const displayFieldsFor = (queryGroup) => {
+    if(Array.isArray(queryGroup.document_fields)) {
+      return queryGroup.document_fields.join(', ');
+    }
+    return queryGroup.document_fields;
+  }
+
   return (
     <div className="w-full px-4">
       <table className="nui-table nui-table--checkbox">
@@ -41,7 +49,7 @@ export default function ListPage({
               </td>
               <td>{queryGroup.http_method}</td>
               <td>{queryGroup.document_uuid}</td>
-              <td>[{queryGroup.document_fields.join(', ')}]</td>
+              <td>[{displayFieldsFor(queryGroup)}]</td>
               <td>
                 <Button
                   onClick={() => { setCurrrentResource(queryGroup); showPane(true); } }

--- a/app/javascript/src/components/Dashboard/QueryGroups/NewForm.jsx
+++ b/app/javascript/src/components/Dashboard/QueryGroups/NewForm.jsx
@@ -143,7 +143,7 @@ export default function NewForm({ onClose, refetch, currentResource }) {
 
           <Input label="Unique Document Field" name="document_uuid" type="String" className="mb-6" />
           <Input label="Fields to Display" name="document_fields" type="String" className="mb-6" />
-          <Textarea label="Transform Response" name="transform_response" rows={8} className="mb-10" />
+          <Textarea label="Transform Response" name="transform_response" rows={8} className="mb-24" />
           <div className="nui-pane__footer nui-pane__footer--absolute">
             <Button
               onClick={onClose}

--- a/app/javascript/src/components/Dashboard/QueryGroups/NewForm.jsx
+++ b/app/javascript/src/components/Dashboard/QueryGroups/NewForm.jsx
@@ -143,7 +143,7 @@ export default function NewForm({ onClose, refetch, currentResource }) {
 
           <Input label="Unique Document Field" name="document_uuid" type="String" className="mb-6" />
           <Input label="Fields to Display" name="document_fields" type="String" className="mb-6" />
-          <Textarea label="Transform Response" name="transform_response" rows={8} className="mb-24" />
+          <Textarea label="Code to Transform Response Data" name="transform_response" rows={8} className="mb-24"/>
           <div className="nui-pane__footer nui-pane__footer--absolute">
             <Button
               onClick={onClose}

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -13,7 +13,7 @@ class Query < ApplicationRecord
 
   def fetch_fresh_results!
     api_response = fetch_api_results
-    if api_response.presence
+    if api_response.presence &&  !(api_response.is_a?(Hash) && api_response[:error].present?)
       result = Result.find_or_initialize_by({
         query_id: self.id,
         query_group_id: self.query_group_id
@@ -22,6 +22,8 @@ class Query < ApplicationRecord
       result.user_id ||= self.user_id
       result.save!
       result
+    else
+      api_response
     end
   end
 

--- a/app/models/scorer.rb
+++ b/app/models/scorer.rb
@@ -37,8 +37,8 @@ class Scorer < ApplicationRecord
     pos_value_map = process_ratings_and_docs
 
     js = JavascriptEvaluator.new({ code: self.code, params: { docPositionAndValues: pos_value_map }})
-    res = js.result
-    res.to_s.to_f
+    evaluated_result = js.result
+    evaluated_result.to_s.to_f
   end
 
   private


### PR DESCRIPTION
* Added the new gem Liquid
* Moved the request body and query string templating to Liquid
* Transforming the response data to the desired format supports custom javascript code
* Better error surfacing in API responses
* Changed label of the transform response field to better legible one
* Better naming of variables in scorer model for javascript evaluator
* Updated example for javascript evaluator
* Request headers field on API source was not displayed properly in the UI because of some serialization, deserialization issues. fixed this.
* Clicking on an edit button of a query group and closing it by clicking on the close button on the top right was having some issues with document_fields being stringified. Fixed this.
* the last field was not visible in the form due to margin in the bottom and the fixed action buttons bar. Fixed this.
* added the context of which query group in Queries & results listing page