### PR TITLE
bug fix: changed the templating to liquid in seed data

### DIFF
--- a/lib/tasks/setup.rake
+++ b/lib/tasks/setup.rake
@@ -166,7 +166,7 @@ def create_query_group!(options = {})
     http_method: 'GET',
     page_size: 10,
     request_body: {},
-    query_string: '/search/suggestions?q=<%= query %>',
+    query_string: '/search/suggestions?q={{ query }}',
     transform_response: '',
     document_uuid: 'name',
     document_fields: ['description', 'version'],


### PR DESCRIPTION
Bug fix

- changed the templating to liquid in seed data. The query group URL templating was using liquid templating. But seed data had erb tempalting. changed this.