### PR TITLE
chore: Assets precompile in docker & doc for env variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN rm -f Gemfile.lock
 RUN bundle lock --add-platform x86_64-linux-musl
 RUN bundle install
 RUN yarn install --check-files
+RUN bundle exec rake assets:precompile
 
 EXPOSE 3000
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -1,0 +1,20 @@
+## Environment Variables
+
+Setting the environment
+```
+RAILS_ENV=production
+RACK_ENV=production
+```
+
+
+Postgresql Database
+```
+PG_DATABASE=rekall_production
+```
+
+
+Disable serving static files from the `/public` folder by default since
+Apache or NGINX already handles this.
+```
+RAILS_SERVE_STATIC_FILES=true
+```


### PR DESCRIPTION
chore: Assets precompile in docker & doc for env variables