### PR TITLE
bugfix: nDCG score greater than one

### DIFF
--- a/lib/tasks/setup.rake
+++ b/lib/tasks/setup.rake
@@ -122,10 +122,11 @@ def create_scorers!
         var topValues = allValues.sort((a, b) => (b - a)),
             idealPositionAndValues = {};
     
-        var sortedPositions = Object.keys(positionAndValues).sort();
+        var sortedPositions = Object.keys(positionAndValues).map(parseFloat).sort((a,b) => a - b);
         for(var i = 0; i < sortedPositions.length; i++){
             idealPositionAndValues[sortedPositions[i]] = topValues[i];
         }
+
         var dcg = findDcgFor(positionAndValues),
             idcg = findDcgFor(idealPositionAndValues);
         var ndcg = (dcg / idcg);


### PR DESCRIPTION
This closes #53 

### Changes
* fixed the bug where nDCG score was going above 1. Here there was a mistake in the default scorer while calculating the ideal DCG. Sorting the keys of pos value map was not right because the keys were strings.