### PR TITLE
bugfix: Fixed broken UI in query result listing page (#70)

### DIFF
--- a/app/javascript/src/components/Common/Navbar/index.jsx
+++ b/app/javascript/src/components/Common/Navbar/index.jsx
@@ -29,9 +29,9 @@ const NavBar = () => {
       </div>
       <div className="flex flex-col items-center justify-between w-full h-full">
         <div className="flex flex-col items-center justify-start w-full pt-4">
-          <NavItem title="Query Groups" link="/query_groups" icon="ri-code-s-slash-line" />
+          <NavItem title="Query Groups" link="/query_groups" icon="ri-mail-send-line" />
           <NavItem title="API Sources" link="/api_sources" icon="ri-database-2-line" />
-          <NavItem title="Scorers" link="/scorers" icon="ri-numbers-line" />
+          <NavItem title="Scorers" link="/scorers" icon="ri-list-settings-line" />
           <NavItem title="Team" link="/teams" icon="ri-team-line" />
           <NavItem
             title="Settings"

--- a/app/javascript/src/components/Dashboard/Results/index.jsx
+++ b/app/javascript/src/components/Dashboard/Results/index.jsx
@@ -9,7 +9,7 @@ import {
   useRouteMatch,
   useLocation
 } from "react-router-dom";
-import { Button, PageLoader, Tooltip, Toastr } from "neetoui";
+import { Button, PageLoader, Tooltip, Toastr, Label } from "neetoui";
 import EmptyState from "components/Common/EmptyState";
 import EmptyNotesListImage from "images/EmptyNotesList";
 import { Header, SubHeader } from "neetoui/layouts";
@@ -109,6 +109,19 @@ const QueryResult = ({ scorer, queryGroup, query, setCurrrentQuery, showQueryEdi
       />
       
       <div className="flex flex-row space-x-4 items-center border-gray-600 p-4 bg-gray-100">
+        { queryResult ? (
+            <>
+              <span className="flex flex-row pl-4">
+                <span className="rounded-md text-white text-xl font-semibold pr-2 pl-2 pt-1 pb-1"
+                    style={{backgroundColor: colorForBinaryRating(queryResult.latest_score || 0.0)}}
+                  > { (queryResult.latest_score || 0.0).toFixed(2) }
+                </span>
+                <Tooltip content={`Scorer: ${scorer.name}, Updated: ${timeSince(new Date(queryResult.updated_at))} ago`} position="bottom" minimal>
+                  <i className="ri-question-line text-xl ml-2"></i>
+                </Tooltip>
+              </span>
+            </>
+          ) : null }
         <Button
             onClick={() => { createSnapshot(); } }
             label="Create Snapshot"
@@ -120,26 +133,10 @@ const QueryResult = ({ scorer, queryGroup, query, setCurrrentQuery, showQueryEdi
         >
           <Tooltip content={`Result Snapshots`} position="bottom" minimal>
             <div className="rounded items-center justify-center">
-              View Snapshots &gt;
+              Snapshots &gt;
             </div>
           </Tooltip>
         </NavLink>
-        { queryResult ? (
-            <>
-              <span className="border rounded-md pl-4">
-                  {scorer.name} &nbsp;&nbsp;
-                  <span className="rounded-md text-white text-xl font-semibold pr-2 pl-2 pt-1 pb-1"
-                    style={{backgroundColor: colorForBinaryRating(queryResult.latest_score || 0.0)}}
-                  > { (queryResult.latest_score || 0.0).toFixed(2) }
-                </span>
-              </span>
-              <Tooltip content="Results Last Refreshed At" position="bottom" minimal>
-                <div className="text-xs text-gray-400">
-                  (Updated {timeSince(new Date(queryResult.updated_at))} ago)
-                </div>
-              </Tooltip>
-            </>
-          ) : null }
       </div>
       
       {queryResult ? (

--- a/app/javascript/src/components/Dashboard/Scorers/ListPage.jsx
+++ b/app/javascript/src/components/Dashboard/Scorers/ListPage.jsx
@@ -14,8 +14,8 @@ export default function ListPage({
           <tr>
             <th> ID </th>
             <th className="text-left">Name</th>
-            <th className="text-left">Scale</th>
             <th className="text-left">Type</th>
+            <th className="text-left">Scale</th>
             <th className="text-left">Actions</th>
           </tr>
         </thead>

--- a/app/javascript/src/components/Dashboard/Scorers/index.jsx
+++ b/app/javascript/src/components/Dashboard/Scorers/index.jsx
@@ -44,7 +44,7 @@ const Scorers = () => {
   return (
     <>
       <Header
-        title="Api Sources"
+        title="Scorers"
         actionBlock={
           <Button
             onClick={() => { setCurrentScorer(false); setShowPane(true); } }


### PR DESCRIPTION
* Fixed broken UI in query result listing page - decluttered the updated at, scorer name etc, moved it under help icon
* Changed the icons for query groups and scorers
* Fixed the scorer listing page column names typo and heading