### PR TITLE
bug: fixed the duplicates in listing query groups and api sources of a team

### DIFF
--- a/app/controllers/api/v1/api_sources_controller.rb
+++ b/app/controllers/api/v1/api_sources_controller.rb
@@ -4,8 +4,8 @@ class Api::V1::ApiSourcesController < Api::V1::BaseController
   before_action :load_api_source, only: [:show, :update, :destroy]
 
   def index
-    api_sources = [current_user.api_sources.active + current_user.team_api_sources].uniq
-    render json: api_sources.flatten
+    api_sources = [current_user.api_sources.active + current_user.team_api_sources].flatten.uniq
+    render json: api_sources
   end
 
   def create

--- a/app/controllers/api/v1/query_groups_controller.rb
+++ b/app/controllers/api/v1/query_groups_controller.rb
@@ -4,8 +4,8 @@ class Api::V1::QueryGroupsController < Api::V1::BaseController
   before_action :load_query_group, only: [:show, :update, :destroy]
 
   def index
-    query_groups = [current_user.query_groups.active + current_user.team_query_groups].uniq
-    render json: query_groups.flatten.as_json(include: :api_source)
+    query_groups = [current_user.query_groups.active + current_user.team_query_groups].flatten.uniq
+    render json: query_groups.as_json(include: :api_source)
   end
 
   def create


### PR DESCRIPTION
This closes #73 .

Fixed the duplicates in listing query groups and api sources of a team. this was a problem with `.uniq` which was done on array of arrays and not flattened array. made the change to do `.uniq` on a flattened array.